### PR TITLE
Add container build workflow

### DIFF
--- a/.github/workflows/build_docker_containers.yml
+++ b/.github/workflows/build_docker_containers.yml
@@ -1,30 +1,63 @@
-# This is a basic workflow to help you get started with Actions
-
 name: build_docker_containers
 
 # Controls when the workflow will run
 on:
-  # Allows you to run this workflow manually from the Actions tab
+  # Run this manually to enable testing, but event setup for auto-trigger will also be complicated
+  # (since action should track a different repo than it lives in)
   workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
+    # standard github runner
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      # Check out docker-specific repo
+      - name: Checkout renode_docker
+        uses: actions/checkout@v4
+        with:
+          path: renode_docker
+      
+      # Check out renode repo itself
+      - name: Checkout renode repo
+        uses: actions/checkout@v4
+        with:
+          repository: SiliconLabsSoftware/renode
+          path: renode
 
-      # Runs a single command using the runners shell
-      - name: Run a one-line script
-        run: echo Hello, world!
-
-      # Runs a set of commands using the runners shell
-      - name: Run a multi-line script
+      # build renode in same environment that renode container will use
+      - name: Build renode_build container
+        working-directory: renode_docker/containers/renode_build
         run: |
-          echo Add other actions to build,
-          echo test, and deploy your project.
+         docker build --platform linux/amd64 --no-cache --build-arg CONTAINER_UID=$(id -u) -t siliconlabsinc/renode_build:latest .
+
+      - name: Build renode inside renode_build container and validate installation
+        run: |
+          docker run --rm --platform linux/amd64 -v $GITHUB_WORKSPACE/renode:/opt/renode $DOCKER_REPO:renode_build bash -c 'cd /opt/renode; ./build.sh --net -p'
+          docker run --rm --platform linux/amd64 -v $GITHUB_WORKSPACE/renode:/opt/renode $DOCKER_REPO:renode_build bash -c 'cd /opt/renode; ./renode --version'
+
+      - name: Move output renode package 
+        run: |
+          ls -l renode
+          ls -l renode/output
+          ls -l renode/output/packages 
+          mv -v renode/output/packages/renode-*.linux-dotnet.tar.gz renode_docker/containers/renode/silabs-renode.tar.gz
+          mkdir renode_docker/containers/renode/renode_package
+          tar -xzf renode_docker/containers/renode/silabs-renode.tar.gz -C renode_docker/containers/renode/renode_package
+          mv -v renode_docker/containers/renode/renode_package/renode_*-dotnet renode_docker/containers/renode/silabs-renode-dotnet
+
+      - name: Build renode container
+        working-directory: renode_docker/containers/renode
+        run: |
+          docker build --platform linux/amd64 --no-cache --build-arg CONTAINER_UID=$(id -u) -t siliconlabsinc/renode:latest .
+
+      - name: Validate renode from inside renode container
+        run: |
+          docker run --rm --platform linux/amd64 siliconlabsinc/renode:latest bash -c 'renode-test /opt/renode/tests/example.robot'
+
+      # To be enabled once builds are verified
+      # - name: Push container to dockerhub
+      #   run: |
+      #     docker image push siliconlabsinc/renode:latest

--- a/.github/workflows/build_docker_containers.yml
+++ b/.github/workflows/build_docker_containers.yml
@@ -6,6 +6,10 @@ on:
   # (since action should track a different repo than it lives in)
   workflow_dispatch:
 
+env: 
+  #temporary
+  DOCKER_REPO: cxlight/cxlight-dockertest
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
@@ -31,7 +35,7 @@ jobs:
       - name: Build renode_build container
         working-directory: renode_docker/containers/renode_build
         run: |
-         docker build --platform linux/amd64 --no-cache --build-arg CONTAINER_UID=$(id -u) -t siliconlabsinc/renode_build:latest .
+         docker build --platform linux/amd64 --no-cache --build-arg CONTAINER_UID=$(id -u) -t $DOCKER_REPO:renode_build .
 
       - name: Build renode inside renode_build container and validate installation
         run: |
@@ -51,13 +55,20 @@ jobs:
       - name: Build renode container
         working-directory: renode_docker/containers/renode
         run: |
-          docker build --platform linux/amd64 --no-cache --build-arg CONTAINER_UID=$(id -u) -t siliconlabsinc/renode:latest .
+          docker build --platform linux/amd64 --no-cache --build-arg CONTAINER_UID=$(id -u) -t $DOCKER_REPO:renode .
 
       - name: Validate renode from inside renode container
         run: |
-          docker run --rm --platform linux/amd64 siliconlabsinc/renode:latest bash -c 'renode-test /opt/renode/tests/example.robot'
+          docker run --rm --platform linux/amd64 $DOCKER_REPO:renode bash -c 'renode-test /opt/renode/tests/example.robot'
 
-      # To be enabled once builds are verified
-      # - name: Push container to dockerhub
-      #   run: |
-      #     docker image push siliconlabsinc/renode:latest
+      - name: Docker login
+        uses: docker/login-action@v3
+        with:
+          #temporary
+          username: ${{ vars.CXLIGHT_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.CXLIGHT_DOCKERHUB_TOKEN }}
+
+
+      - name: Push container to dockerhub
+        run: |
+          docker image push $DOCKER_REPO:renode

--- a/.github/workflows/build_docker_containers.yml
+++ b/.github/workflows/build_docker_containers.yml
@@ -7,8 +7,7 @@ on:
   workflow_dispatch:
 
 env: 
-  #temporary
-  DOCKER_REPO: cxlight/cxlight-dockertest
+  DOCKER_REPO: siliconlabsinc/renode_container
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -64,7 +63,6 @@ jobs:
       - name: Docker login
         uses: docker/login-action@v3
         with:
-          #temporary
           username: ${{ secrets.SILABSW_PUBLIC_DOCKER_USERNAME }}
           password: ${{ secrets.SILABSW_PUBLIC_DOCKER_PAT}}          
 

--- a/.github/workflows/build_docker_containers.yml
+++ b/.github/workflows/build_docker_containers.yml
@@ -65,8 +65,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           #temporary
-          username: ${{ vars.CXLIGHT_DOCKERHUB_USERNAME }}
-          password: ${{ secrets.CXLIGHT_DOCKERHUB_TOKEN }}
+          username: ${{ secrets.SILABSW_PUBLIC_DOCKER_USERNAME }}
+          password: ${{ secrets.SILABSW_PUBLIC_DOCKER_PAT}}          
 
 
       - name: Push container to dockerhub

--- a/.github/workflows/build_docker_containers.yml
+++ b/.github/workflows/build_docker_containers.yml
@@ -70,5 +70,6 @@ jobs:
 
 
       - name: Push container to dockerhub
+        if: github.ref == 'refs/heads/main'
         run: |
           docker image push $DOCKER_REPO:renode

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # renode_docker
-(WORK IN PROGRESS)
 
-Repository containing a Docker workflow for the Silicon Labs public fork of Renode.  
-The container produced by the Dockerfile has this version of Renode preinstalled, while the Github Actions workflow builds and packages Renode upon changes to the main
-branch of SiliconLabsSoftware/renode, and builds the container based on this package.
+Repository containing Docker workflows based around the Silicon Labs public fork of Renode. 
+
+### renode_build container
+
+Container including an environment for building and packaging Renode (from source at SiliconLabsSoftware/renode).  Requires the Renode repository to be mounted into the container before building, and is mostly intended for CI workflows to provide access to the environment they need to package Renode for the renode container.
+The build environment is currently based on .NET 8.0 and Ubuntu 24.04 + x86_64 architecture.
+
+### renode container
+
+Container includes a preinstalled version of Renode built from the renode_build container. 
+Includes 'renode' (to launch the Renode monitor) and 'renode-test' (to run one of the Robot tests packaged inside the container) as commands on PATH.

--- a/containers/renode/Dockerfile
+++ b/containers/renode/Dockerfile
@@ -1,0 +1,83 @@
+# Dockerfile to run Renode, built from SiLabs public fork
+# Uses .NET to build, based on x86_64 architecture
+
+FROM ubuntu:24.04
+
+# -----------------------------------------------------------------------------
+# metadata
+LABEL maintainer="chlight@silabs.com"
+LABEL description="Container w/ built-in version of SiLabs renode (public fork)"
+
+# -----------------------------------------------------------------------------
+# scaffolding
+ARG DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8
+ENV LOG4J_FORMAT_MSG_NO_LOOKUPS=true
+ENV CONTAINER_USER=renoder
+ARG CONTAINER_UID=1001
+ARG USER_HOMEDIR=/home/${CONTAINER_USER}
+ENV TZ=UTC
+RUN ln -snf /usr/share/zoneinfo/UTC /etc/localtime && echo UTC > /etc/timezone
+
+# -----------------------------------------------------------------------------
+# Install .NET
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN apt-get update && apt-get install -y \
+        ca-certificates \
+        dotnet-sdk-8.0 \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+# dependencies
+RUN apt-get update && apt-get install -y \
+        autoconf \
+        automake \
+        cmake \
+        coreutils \
+        g++ \
+        git \
+        gtk-sharp3 \
+        libgtk-3-dev \
+        libtool \
+        policykit-1 \
+        python3 \
+        python3-pip \
+        uml-utilities \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+# -----------------------------------------------------------------------------
+# dependencies for robot test-framework (listed in `renode/tests/requirements.txt`)
+RUN pip3 install --no-cache-dir --break-system-packages \
+        construct==2.10.* \
+        psutil==5.9.* \
+        pyelftools==0.30 \
+        pyyaml==6.0.* \
+        requests==2.27.* \
+        robotframework-retryfailed==0.2.* \
+        robotframework==6.1 \
+        pybgapi==1.3.*
+
+
+# -----------------------------------------------------------------------------
+# Install the renode built from Actions inside SiliconLabsSoftware/renode_docker
+RUN mkdir -p /opt/renode
+COPY silabs-renode-dotnet /opt/renode
+RUN ls /opt/renode
+ENV PATH=/opt/renode:$PATH
+
+# -----------------------------------------------------------------------------
+# create local, unprivileged user
+RUN useradd ${CONTAINER_USER} --uid ${CONTAINER_UID} --no-log-init --create-home --shell /bin/bash \
+    && chown ${CONTAINER_USER} /opt
+
+# -----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
+# switch to unprivileged user
+USER  ${CONTAINER_USER}
+WORKDIR ${USER_HOMEDIR}
+
+# -----------------------------------------------------------------------------
+# cheat sheet
+# docker build --platform linux/amd64 --build-arg CONTAINER_UID=`id -u` -t renode:local -f Dockerfile .
+# docker run --rm -it --platform linux/amd64 renode:local
+# > renode-test /opt/renode/tests/example.robot /opt/renode/tests/unit-tests/emulation-environment.robot

--- a/containers/renode_build/Dockerfile
+++ b/containers/renode_build/Dockerfile
@@ -1,0 +1,93 @@
+#Container to build and test Renode for an Ubuntu Linux environment.
+#Currently this only supports x86_64/amd64 architecture and building Renode with Mono,
+#but future support for .NET and ARM64 is planned.
+
+FROM ubuntu:24.04
+
+# -----------------------------------------------------------------------------
+# metadata
+LABEL maintainer="chlight@silabs.com"
+LABEL description="Container used to build, test, and package the SiLabs fork of Renode for Linux"
+
+# -----------------------------------------------------------------------------
+# scaffolding
+ARG DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8
+ENV LOG4J_FORMAT_MSG_NO_LOOKUPS=true
+ENV CONTAINER_USER=buildengineer
+ARG CONTAINER_UID=1001
+ARG USER_HOMEDIR=/home/${CONTAINER_USER}
+ENV TZ=UTC
+RUN ln -snf /usr/share/zoneinfo/UTC /etc/localtime && echo UTC > /etc/timezone
+
+# -----------------------------------------------------------------------------
+# Install .NET
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN apt-get update && apt-get install -y \
+        ca-certificates \
+        dotnet-sdk-8.0 \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+# dependencies: packages required to BUILD
+# https://renode.readthedocs.io/en/latest/advanced/building_from_sources.html#prerequisites
+RUN apt-get update && apt-get install -y \
+        autoconf \
+        automake \
+        cmake \
+        coreutils \
+        g++ \
+        git \
+        gtk-sharp3 \
+        libgtk-3-dev \
+        libtool \
+        policykit-1 \
+        python3 \
+        python3-pip \
+        uml-utilities \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+# dependencies: packages required to PACKAGE
+# https://renode.readthedocs.io/en/latest/advanced/building_from_sources.html#creating-packages
+RUN apt-get update && apt-get install -y \
+        libarchive-tools \
+        rpm \
+        ruby \
+        ruby-dev \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/* \
+    && gem install dotenv -v 2.8.1 \
+    && gem install fpm
+
+# -----------------------------------------------------------------------------
+# dependencies for robot test-framework (listed in `renode/tests/requirements.txt`)
+RUN pip3 install --no-cache-dir --break-system-packages \
+        construct==2.10.* \
+        psutil==5.9.* \
+        pyyaml==6.0.* \
+        requests==2.27.* \
+        robotframework-retryfailed==0.2.* \
+        robotframework==6.1 \
+        pybgapi==1.3.*
+
+# -----------------------------------------------------------------------------
+# fixups
+# cross-mount /opt/renode 'git' has some issues ... these aim to work around them
+RUN git config --global --add safe.directory /opt/renode \
+    && git config --global --add safe.directory /opt/renode/lib/resources
+
+# -----------------------------------------------------------------------------
+# create local, unprivileged user
+RUN useradd ${CONTAINER_USER} --uid ${CONTAINER_UID} --no-log-init --create-home --shell /bin/bash
+
+# -----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
+# switch to unprivileged user
+USER  ${CONTAINER_USER}
+WORKDIR /opt/renode
+
+
+# -----------------------------------------------------------------------------
+# cheat sheet
+# docker build --no-cache --platform linux/amd64 --build-arg CONTAINER_UID=`id -u` -t renode-dev:local -f Dockerfile .
+# docker run --rm -it --platform linux/amd64 -v ~/repos/renode:/opt/renode renode-dev:local
+# > ./build.sh -c ; ./build.sh ; ./build.sh -p "


### PR DESCRIPTION
Add Dockerfiles to create renode_build and renode containers, along with a Github Actions workflow to build these containers and publish the renode container (which has our fork of renode preinstalled).

Things that are planned to be changed in the future:

- Use a Silicon Labs dockerhub repo to publish the image (currently uses my own test repo)
_- Update the containers to use a newer Ubuntu version and build Renode with .NET (after such changes can be tested and validated internally)._  already done